### PR TITLE
Add support for CentOS, RedHat & Fedora

### DIFF
--- a/script.sh
+++ b/script.sh
@@ -20,18 +20,17 @@ if   which apt-get; then OS_KIND="debian"
 elif which yum;     then OS_KIND="fedora"
 fi
 
-# Update instance
-
-locale-gen en_GB.UTF-8
-
 #Install dependencies
 
 case "$OS_KIND" in
   debian)
+    locale-gen en_GB.UTF-8
     apt-get update
     apt-get install -y python-pip jq
     ;;
   fedora)
+    echo "en_GB.UTF-8" > /etc/locale.conf
+    yum install -y python #Fedora doesn't have Python pre-installed
     #pip & jq aren't in the yum repos
     curl -O https://bootstrap.pypa.io/get-pip.py
     python get-pip.py


### PR DESCRIPTION
### Problem

Unable to run script on non-debian based OS.

### Solution

Still a work in progress, but looking for initial feedback. Also includes the changes from #7 to make sure I don't duplicate stuff later.
Big changes are:
* Query the EC2 Metadata service directly, as the `ec2metadata` script isn't available on other distros.
* Remove use of `sudo` from the script, as we're running as root already
* Configure root to be allowed to `sudo` without a tty. This conflicts with the above point, but Tutum's install script tries to use `sudo` and fails otherwise
* Removing the Slack notification, talked about in #3 

Currently tested and working on Ubuntu 14.04, RHEL 7, CentOS 7 (`ami-33734044`) and Fedora 23 (`	ami-e00dd293`).